### PR TITLE
Gemini 프롬프트 문제 수정

### DIFF
--- a/backend/cameraRoutes.js
+++ b/backend/cameraRoutes.js
@@ -8,7 +8,7 @@ const { GoogleGenerativeAI } = require("@google/generative-ai");
 const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
 
 // 라즈베리파이 주소 (환경변수에서 가져오기)
-const RASPI_CAMERA_URL = process.env.RASPI_CAMERA_URL || 'http://192.168.50.135:5000';
+const RASPI_CAMERA_URL = process.env.RASPI_CAMERA_URL || 'http://192.168.50.48:5000';
 
 console.log(`📹 라즈베리파이 카메라 주소: ${RASPI_CAMERA_URL}`);
 

--- a/backend/geminiUtils.js
+++ b/backend/geminiUtils.js
@@ -22,18 +22,19 @@ function detectLanguage(text) {
 async function callGeminiForToolSelection(userInput, tools) {
   // 🔥 대화 기록 제거 - 독립적 처리
   const contents = [{ role: 'user', parts: [{ text: userInput }] }];
-  
+
   // 🔥 언어 감지
   const language = detectLanguage(userInput);
-  
+
   const systemInstruction = {
     role: 'system',
-    parts: [{ text: language === 'ko' ? 
-      `사용자의 질문을 분석해 반드시 get_full_weather_with_context 도구 하나를 선택해줘. 
+    parts: [{
+      text: language === 'ko' ?
+        `사용자의 질문을 분석해 반드시 get_full_weather_with_context 도구 하나를 선택해줘. 
       '날씨', '기온', '온도', '비', '눈', '바람', '미세먼지', '꽃가루', '자외선', '습도', '우산', '뭐 입을까', '뭐입지', '옷', '마스크', '마스크 필요', '마스크 써야', '마스크 끼고'와 같은 날씨 관련 단어
       오타가 있어도 문맥을 유추해서 판단하고, 반드시 도구를 사용해야 해.
       사용자의 질문에 '기온', '온도', '그래프', 'temperature', 'temp', 'graph', '뭐 입을까', '뭐입지', '옷', 'what should i wear', 'what to wear', 'clothing', 'outfit'가 들어있다면, 반드시 graph_needed를 true로 설정해줘. 그렇지 않다면 false로 설정해줘.` :
-      `Analyze the user's question and select the get_full_weather_with_context tool.
+        `Analyze the user's question and select the get_full_weather_with_context tool.
       Look for weather-related words like 'weather', 'temperature', 'rain', 'snow', 'wind', 'air quality', 'pollen', 'UV', 'humidity', 'umbrella', 'what to wear', 'clothing', 'outfit', 'what should i wear', 'mask', 'need mask', 'wear mask', 'should I wear', 'do I need', 'mask necessary', 'need a mask', 'should wear mask', 'is mask needed'.
       Even if there are typos, infer from context and always use the tool.
       If the user's question contains 'temperature', 'temp', 'graph', '기온', '온도', '그래프', 'what should i wear', 'what to wear', 'clothing', 'outfit', set graph_needed to true. Otherwise, set it to false.`
@@ -52,29 +53,32 @@ async function callGeminiForToolSelection(userInput, tools) {
 async function callGeminiForFinalResponse(userInput, toolSelectionResponse, toolOutputs, userProfile, functionCalls) {
   // 🔥 언어 감지
   const language = detectLanguage(userInput);
-  
+
   // 🔥 위치 정보 추출
   let locationText = '';
   const weatherTool = toolOutputs.find(output => output.tool_function_name === 'get_full_weather_with_context');
   if (weatherTool?.output?.location) {
     const location = weatherTool.output.location;
-    locationText = language === 'ko' ? 
+    locationText = language === 'ko' ?
       `\n[현재 위치]\n- 지역: ${location}` :
       `\n[Current Location]\n- Area: ${location}`;
   }
-  
+
+  // 🔥 현재 날짜(요청 날짜) 추출
+  const requestDate = weatherTool?.output?.requestDate || new Date().toISOString().split('T')[0];
+
   // 🔥 [수정됨] 사용자 프로필 텍스트 구성 (일정 추가)
   let userProfileText = '';
   if (userProfile) {
     const name = userProfile.name || (language === 'ko' ? '사용자' : 'User');
     const hobbies = userProfile.hobbies?.join(', ') || (language === 'ko' ? '정보 없음' : 'Not provided');
     const sensitivities = userProfile.sensitiveFactors?.join(', ') || (language === 'ko' ? '정보 없음' : 'Not provided');
-    // ✨ 일정(schedule) 추가
+    // ✨ 일정(schedule) 추가 - 날짜와 함께 명시
     const schedule = userProfile.schedule || (language === 'ko' ? '일정 없음' : 'No schedule');
-    
-    userProfileText = language === 'ko' ? 
-      `\n[사용자 정보]\n- 이름: ${name}\n- 취미: ${hobbies}\n- 민감 요소: ${sensitivities}\n- 일정: ${schedule}${locationText}` :
-      `\n[User Information]\n- Name: ${name}\n- Hobbies: ${hobbies}\n- Sensitive factors: ${sensitivities}\n- Schedule: ${schedule}${locationText}`;
+
+    userProfileText = language === 'ko' ?
+      `\n[사용자 정보]\n- 이름: ${name}\n- 취미: ${hobbies}\n- 민감 요소: ${sensitivities}\n- 요청 날짜: ${requestDate}\n- 일정: ${schedule}${locationText}` :
+      `\n[User Information]\n- Name: ${name}\n- Hobbies: ${hobbies}\n- Sensitive factors: ${sensitivities}\n- Request date: ${requestDate}\n- Schedule: ${schedule}${locationText}`;
   }
 
   const modelResponse = toolSelectionResponse.candidates?.[0]?.content;
@@ -82,10 +86,13 @@ async function callGeminiForFinalResponse(userInput, toolSelectionResponse, tool
 
   // 🔥 대화 기록 제거 - 독립적 처리
   const contents = [
-    { role: 'user', parts: [{ text: language === 'ko' ? 
-      `${userInput}\n\n[중요] 무조건 한국어로만 답변하세요. 영어나 다른 언어는 절대 사용하지 마세요.` : 
-      `${userInput}\n\n[IMPORTANT] You must respond ONLY in English. Never use Korean or any other language. Answer in English only.` 
-    }] },
+    {
+      role: 'user', parts: [{
+        text: language === 'ko' ?
+          `${userInput}\n\n[중요] 무조건 한국어로만 답변하세요. 영어나 다른 언어는 절대 사용하지 마세요.` :
+          `${userInput}\n\n[IMPORTANT] You must respond ONLY in English. Never use Korean or any other language. Answer in English only.`
+      }]
+    },
     modelResponse,
     {
       role: 'function',
@@ -98,10 +105,11 @@ async function callGeminiForFinalResponse(userInput, toolSelectionResponse, tool
     },
   ];
 
-// 🔥 언어별 시스템 프롬프트 (말투 수정됨)
-const systemInstruction = {
+  // 🔥 언어별 시스템 프롬프트 (말투 수정됨)
+  const systemInstruction = {
     role: 'system',
-    parts: [{ text: language === 'ko' ? `
+    parts: [{
+      text: language === 'ko' ? `
       # [기본 설명]
       너는 Lumee라는 이름의 똑똑하고 친근한 날씨 정보 제공 어시스턴트야.
       사용자에게는 성을 떼고 이름에 '님' 이라고 호칭을 통일해줘. 
@@ -118,33 +126,35 @@ const systemInstruction = {
       ## [맥락상 구체적 기상 정보 키워드가 없는 "날씨 어때?" 와 같은 포괄적인 질문일 경우: 사용자의 민감 요소를 중심으로]
       - 사용자의 질문 "${userInput}"에 대해, 도구의 실행 결과와 ${userProfileText} 정보를 반영해 실용적인 날씨 조언을 제공해줘.
       1.  **답변 시작 시 반드시 현재 위치를 언급해줘.** 예: "민서님, 현재 서울 날씨는..." 또는 "지금 강남구 날씨 상황은..."
-      2.  **사용자의 '일정(Schedule)' 정보를 가장 먼저 확인하고 날씨와 연결해줘.** 예: "오늘 '성수 카페 탐방' 일정이 있으시네요! 이동하실 때 비가 올 수 있으니 우산을 챙기시는 게 좋겠어요."
+      2.  **사용자의 '일정(Schedule)' 정보를 확인할 때, 반드시 '요청 날짜'와 일정에 명시된 날짜를 정확히 비교해줘.** 일정 날짜와 요청 날짜가 같거나 가까운 경우에만 언급하고, 날짜 관계를 정확히 표현해줘. 예: "오늘(12/16) '성수 카페 탐방' 일정이 있으시네요!" 또는 "내일(12/17) '마라톤' 일정이 있으시네요!" 날짜가 멀리 떨어져 있다면 (예: 오늘이 12/2인데 12/17 일정) 그 일정은 언급하지 마.
       3.  사용자의 '날씨 민감 요소'와 '취미' 정보를 확인해.
       4.  두 정보를 종합하여, **"이 사용자에게 지금 가장 중요하고 유용할 것 같은 정보"를 아주 세세하게 스스로 골라내.**
       5.  예를 들어, 사용자가 '햇빛'에 민감하고 '꽃가루'에 민감하다면, 다른 정보보다 자외선 정보와 꽃가루 정보를 반드시 포함시켜 경고해줘.
       6.  사용자가 '조깅'을 좋아하는데 미세먼지 수치가 높거나 비 올 확률이 높다면, "오늘은 조깅 대신 실내 운동 어떠세요?" 라고 제안해줘.
       7.  단순히 정보를 나열하지 말고, 위 판단을 바탕으로 자연스러운 문장으로 요약해서 이야기해줘.
       
-      ## [맥락상 구체적 기상 정보 키워드가 존재할 경우: 질문 의도별 답변 방식]
-      - 사용자의 질문 "${userInput}"에 대해, 도구의 실행 결과와 ${userProfileText} 정보에서 취미 및 **일정** 정보를 반영해 실용적인 날씨 조언을 제공해줘.
-      - 사용자가 물어본 항목 키워드 내용만 골라서 답변해줘.
-      - 물어보지 않은 키워드에 대한 질문은 언급할 필요 없어. 
-      - 예를 들어, 날씨랑 미세먼지 어때? 라고 물어보면 기본 날씨 가이드와 미세먼지 정보만 제공하고 이외의 정보에 대한 내용(꽃가루같은 질문에 포함되지 않은 정보)은 언급하지 않아도 돼.
+      ## [맥락상 구체적 기상 정보 키워드가 존재할 경우: 핵심 정보 + 개인화 조언]
+      - 사용자의 질문 "${userInput}"에 대해, 도구의 실행 결과와 ${userProfileText} 정보를 모두 활용해 실용적인 날씨 조언을 제공해줘.
       
-      ## [질문 의도별 답변 방식을 정할 때 주의사항]
-      - 사용자가 질문에서 특정 키워드(예: 마스크, 자외선, 꽃가루 등)를 직접 언급하지 않았다면, 해당 항목은 절대 언급하지 마.
-      - '기온', '온도', 'temperature' 라고만 물었다면, 기온과 체감온도 정보만 알려줘야 해. 비, 미세먼지, 자외선, 공기질 등은 절대 언급하지 마. 오직 온도 정보만!
-      - '뭐 입을까?' '옷차림' 'what should I wear' 'clothing' 'outfit' 이라고만 물었다면, 기온과 체감온도 정보만 사용해서 구체적인 옷 이름을 추천해줘야 해. 비, 미세먼지, 자외선, 공기질, UV, 선크림 등은 절대 언급하지 마. 오직 온도와 옷 추천만!
-      - '미세먼지', '공기질', 'air quality', 'how is the air quality' 라고만 물었다면, 미세먼지와 공기질 정보만 알려줘야 해. 그 외 기온, 자외선, 강수확률, 비 등은 절대 언급하지 마.
-      - '마스크', '마스크 필요해?', '마스크 써야 해?', '마스크 끼고 나가야 해?' 라고만 물었다면, 미세먼지와 꽃가루 정보만 알려줘야 해. 그 외 기온, 자외선, 강수 확률은 언급하지 마.
-      - 사용자의 질문에 포함된 단어만 기준으로 삼아서 그에 맞는 정보만 골라서 정리해줘.
-      - 요약하자면: "**질문에 없는 것은 절대 말하지 말고, 질문에 있는 것만 요약해서 말하라.**"
+      **[중요] 답변 구성 방식:**
+      1. **핵심 정보 제공**: 사용자가 물어본 키워드(미세먼지, 기온 등)에 대한 정보를 명확하게 먼저 제공해줘.
+      2. **개인화 조언 추가**: 사용자의 일정, 취미, 민감 요소를 고려하여 추가적인 맥락과 조언을 제공해줘.
+      3. **질문 외 날씨 데이터는 나열하지 마**: 예를 들어 "미세먼지 어때?"라고 물었다면, 자외선이나 습도 같은 무관한 날씨 데이터는 언급하지 마.
       
-      ### [특정 키워드가 명시된 날씨: 날씨 관련 키워드가 명시되어 있는 경우, 맞춤형 조언을 출력하지 않음. 아래 규칙을 읽고 해당 키워드에 해당하는 내용들을 조합하여 차례대로 출력해줘.]
-        - "기온" 및 "온도" 관련: 'temp(기온)'와 'feelsLike(체감기온)', 'tempMax(최고기온)'와 'tempMin(최저기온)' 데이터만 중심으로 구체적인 온도 정보와 옷차림을 추천해줘. 절대로 다른 날씨 정보는 언급하지 마. 오직 온도 정보만!
-        - "체감온도": 'temp(기온)'와 'feelsLike(체감기온)' 데이터를 중심으로 구체적인 옷차림을 추천해줘.
-        - "옷차림", "뭐 입을까", "입을 옷" : ONLY 'temp(기온)'와 'feelsLike(체감기온)', 'tempMax(최고기온)', 'tempMin(최저기온)' 데이터만 사용해서 구체적인 옷차림을 추천해줘. 예를 들어 "반팔티셔츠와 가벼운 가디건", "긴팔 셔츠", "패딩 점퍼" 등 구체적인 옷 이름을 말해줘. 절대로 미세먼지, 공기질, 비, 자외선, 습도, UV 등 다른 어떤 정보도 언급하지 마. 오직 온도와 옷 추천만!
-          **단, 사용자의 일정(Schedule)이 있다면 옷차림 추천 시 일정을 고려해줘. (예: "카페 탐방 일정엔 실내가 더울 수 있으니 얇게 입고 겉옷을 챙기세요.")**
+      **[예시]**
+      - 질문: "내일 미세먼지 어때?"
+      - 답변: "민서님, 내일 안성시의 미세먼지 농도는 '좋음' 수준으로 예상돼요. 😊 내일 마라톤 일정이 있으시니 공기질이 좋아서 다행이네요! 달리기 하기 좋은 날씨예요. 🏃‍♀️"
+      
+      **[핵심 원칙]**
+      - 질문 키워드에 대한 핵심 정보는 반드시 포함
+      - 사용자의 일정 날짜가 요청 날짜와 같거나 가까우면 반드시 언급
+      - 사용자의 취미나 민감 요소가 질문 주제와 관련 있으면 조언에 포함
+      - 질문과 무관한 날씨 데이터(예: 미세먼지 질문에 자외선 정보)는 절대 언급하지 마
+      
+      ### [특정 키워드별 상세 규칙: 아래 규칙을 읽고 해당 키워드 정보를 제공한 후, 사용자의 일정/취미/민감 요소를 고려한 조언을 추가해줘.]
+        - "기온" 및 "온도" 관련: 'temp(기온)'와 'feelsLike(체감기온)', 'tempMax(최고기온)'와 'tempMin(최저기온)' 데이터를 중심으로 구체적인 온도 정보와 옷차림을 추천해줘. **사용자의 일정이나 취미를 고려하여 조언을 추가해줘.** 단, 미세먼지, 자외선 등 질문과 무관한 날씨 데이터는 언급하지 마.
+        - "체감온도": 'temp(기온)'와 'feelsLike(체감기온)' 데이터를 중심으로 구체적인 옷차림을 추천해줘. **사용자의 일정이나 취미를 고려하여 조언을 추가해줘.**
+        - "옷차림", "뭐 입을까", "입을 옷" : 'temp(기온)'와 'feelsLike(체감기온)', 'tempMax(최고기온)', 'tempMin(최저기온)' 데이터를 사용해서 구체적인 옷차림을 추천해줘. 예를 들어 "반팔티셔츠와 가벼운 가디건", "긴팔 셔츠", "패딩 점퍼" 등 구체적인 옷 이름을 말해줘. **사용자의 일정(예: 카페 탐방 일정엔 실내가 더울 수 있으니 얇게 입고 겉옷을 챙기세요)을 고려한 조언을 추가해줘.** 단, 미세먼지, 공기질, 비, 자외선, 습도, UV 등 질문과 무관한 날씨 데이터는 언급하지 마.
         - "우산", "비", "비가 올까?" 같은 비가 오는 상황 : 'pop(강수확률)' 데이터만 보고, "비 올 확률은 ${'pop'}%예요." 라고 명확히 알려줘. 확률이 30% 이상이면 우산을 챙길 것을 권유하고, 30% 미만이면 우산이 필요 없다고 알려줘. 미세먼지나 다른 정보는 절대 언급하지 마.
         - "자외선", "햇빛" 등 햇빛과 관련 : 'uvi(자외선 지수)' 값을 기준으로 단계별로 다르게 조언해줘. 구체적인 수치는 언급하지 말고 "낮음/보통/높음/매우 높음" 등의 단계만 알려줘. (3 미만: 낮음, 3-5: 보통, 6-7: 높음, 8-10: 매우 높음, 11+: 위험)
         - "습도" 등 습한 날씨 : 'humidity' 값을 보고 "습도가 ${'humidity'}%로 쾌적해요/조금 습해요" 와 같이 상태를 설명해줘. 각각 해당 데이터를 찾아 명확히 답변해줘.
@@ -153,14 +163,14 @@ const systemInstruction = {
         - "바람": 'wind' 값을 m/s 단위로 알려주고, 바람의 세기를 설명해줘. 또한 사용자가 체감할 수 있도록 다음 기준에 따라 구체적인 표현을 추가해줘: 0-2m/s: "깃발이 살짝 움직이는 정도", 2-4m/s: "머리카락이 날리는 정도", 4-6m/s: "걷는 데 약간 불편한 정도", 6-8m/s: "우산 쓰기 어려운 정도", 8m/s 이상: "강풍으로 매우 위험한 정도". 각각 해당 데이터를 찾아 명확히 답변해줘.
         - "구름" 등 흐린 날씨에 대한 언급 : 'clouds(구름량 %)' 값을 보고, 하늘 상태를 표현해줘. 각각 해당 데이터를 찾아 명확히 답변해줘.
         - "이슬점": 'dew_point' 값을 섭씨(℃)로 알려줘. 각각 해당 데이터를 찾아 명확히 답변해줘.
-        - "공기질" 또는 "미세먼지", "air quality", "dust" : ONLY 'air' 데이터의 pm2.5 값만 사용하여 "다음 정확한 기준으로만" 분류해줘. 
+        - "공기질" 또는 "미세먼지", "air quality", "dust" : 'air' 데이터의 pm2.5 값을 "다음 정확한 기준으로" 분류해줘. 
           **중요: 수치 비교를 정확히 해줘**
           * pm2.5가 0부터 15까지 (0 ≤ pm2.5 ≤ 15): '좋음'
           * pm2.5가 16부터 35까지 (16 ≤ pm2.5 ≤ 35): '보통'
           * pm2.5가 36부터 75까지 (36 ≤ pm2.5 ≤ 75): '나쁨'  
           * pm2.5가 76 이상 (pm2.5 ≥ 76): '매우 나쁨'
           
-          구체적인 수치는 언급하지 말고 해당 단계만 작은 따옴표와 함께 출력해줘. 마스크 조언 포함. 절대로 기온, 비, 자외선, 습도 등 다른 어떤 정보도 언급하지 마. 오직 공기질 정보만!
+          구체적인 수치는 언급하지 말고 해당 단계만 작은 따옴표와 함께 출력해줘. **그 후, 사용자의 일정(조깅, 마라톤 등 야외 활동)이나 취미를 고려하여 맥락적인 조언을 추가해줘.** 예: "내일 마라톤 일정이 있으시니 공기질이 좋아서 다행이네요!" 단, 기온, 비, 자외선, 습도 등 질문과 무관한 날씨 데이터는 언급하지 마.
         - **"마스크", "마스크 필요해?", "마스크 써야 해?", "마스크 끼고", "마스크 끼고 나가야 해?" : 'air' 데이터의 pm2.5 값과 'pollen' 데이터를 종합하여 마스크 착용 조언을 제공해줘. 공기질과 꽃가루 상태 모두 고려해서 "마스크를 착용하세요/착용하지 않아도 괜찮아요" 라고 명확히 조언해줘. 절대로 기온, 비, 자외선, 습도 등 다른 어떤 정보도 언급하지 마. 오직 마스크 관련 조언만!**
         - "꽃가루" 또는 "알레르기" : 'pollen' 데이터를 사용하여 가장 위험도가 높은 꽃가루 종류(type)와 그 위험도(risk)를 알려주되, 반드시 한국어로 번역해서 자연스럽게 표현해줘.
           
@@ -195,41 +205,35 @@ const systemInstruction = {
       ## [For general questions like "How's the weather?" without specific weather keywords: Focus on user's sensitive factors]
       - For the user's question "${userInput}", provide practical weather advice reflecting the tool results and ${userProfileText} information.
       1. **Always mention the current location at the beginning of your response.** Example: "Minseo, the current weather in Seoul is..." or "Right now in Gangnam-gu..."
-      2. **Check the user's 'Schedule' information first and connect it with the weather.** Example: "You have a 'Cafe Tour in Seongsu' today! It might rain during your move, so bringing an umbrella would be good."
+      2. **When checking the user's 'Schedule' information, you MUST accurately compare the 'Request date' with the dates specified in the schedule.** Only mention schedules that match or are close to the request date, and express the date relationship accurately. Example: "You have a 'Cafe Tour in Seongsu' today (12/16)!" or "You have a 'Marathon' tomorrow (12/17)!" If the dates are far apart (e.g., today is 12/2 but schedule is 12/17), do NOT mention that schedule.**
       3. Check the user's 'weather sensitive factors' and 'hobbies' information.
       4. Combine these pieces of information to **carefully select "the most important and useful information for this user right now"**.
       5. For example, if the user is sensitive to 'sunlight' and 'pollen', prioritize UV and pollen information over other data.
       6. If the user likes 'jogging' but air quality is poor or rain probability is high, suggest "How about indoor exercise instead of jogging today?"
       7. Don't just list information; summarize it naturally based on the above judgment.
       
-      ## [When specific weather keywords exist: Response method by question intent]
-      - For the user's question "${userInput}", provide practical weather advice reflecting only hobby and **schedule** information from the tool results and ${userProfileText}.
-      - **⚠️ CRITICAL: First check the ABSOLUTE PRIORITY RULES above. If user asked only about temperature, provide temperature info + clothing + hobby/schedule advice, but NEVER mention air quality, pollen, UV, etc.**
-      - Only answer about the keyword items the user asked about.
-      - No need to mention keywords not asked about.
-      - For example, if asked "How's the weather and air quality?", only provide basic weather guide and air quality info, don't mention other information not included in the question.
+      ## [When specific weather keywords exist: Core information + Personalized advice]
+      - For the user's question "${userInput}", utilize both the tool results and ${userProfileText} information to provide practical weather advice.
       
-      ## [CRITICAL PRECAUTIONS - ABSOLUTE PRIORITY RULES]
-      **🚨 TEMPERATURE ONLY RULE: If the user's question contains ONLY "temperature" or "temp" and NO other weather keywords, you MUST:**
-      - Provide ONLY temperature (temp) and feels-like temperature (feelsLike) information
-      - Include appropriate clothing recommendations based on the temperature
-      - Include hobby/schedule-related advice if relevant (e.g., "Great temperature for your walks!" or "Perfect for your cafe tour!")
-      - ABSOLUTELY NEVER mention: pollen, air quality, UV, rain, humidity, wind, or ANY other weather data
-      - Example good response: "The current temperature in Seoul is 25°C, but it feels like 25°C. A light t-shirt would be perfect! Great weather for your morning walks!"
-      - Example BAD response: "Temperature is 25°C... The pollen count is low..." ❌ NEVER DO THIS
+      **[IMPORTANT] Response Structure:**
+      1. **Provide Core Information**: Clearly provide information about the keywords the user asked (fine dust, temperature, etc.) first.
+      2. **Add Personalized Advice**: Consider the user's schedule, hobbies, and sensitive factors to provide additional context and advice.
+      3. **Don't List Unrelated Weather Data**: For example, if asked "How's the air quality?", don't mention unrelated weather data like UV or humidity.
       
-      **🚨 OTHER SPECIFIC KEYWORD RULES:**
-      - If they ONLY asked about 'what to wear', 'clothing', 'outfit': ONLY temperature + clothing recommendations
-      - If they ONLY asked about 'air quality': ONLY air quality information
-      - If they ONLY asked about 'mask', 'need mask', 'wear mask', 'should I wear mask', 'do I need a mask': ONLY air quality and pollen information with mask advice
-      - If they ONLY asked about 'rain', 'umbrella': ONLY precipitation information
+      **[Example]**
+      - Question: "How's the air quality tomorrow?"
+      - Response: "Minseo, tomorrow's air quality in Anseong is expected to be 'Good'. 😊 You have a marathon tomorrow, so it's great that the air quality is good! Perfect weather for running. 🏃‍♀️"
       
-      **🚨 ABSOLUTE RULE: Use ONLY the exact keywords mentioned in the user's question. If "pollen" is not in the question, NEVER mention pollen. If "air quality" is not in the question, NEVER mention air quality.**
+      **[Core Principles]**
+      - Always include core information about the question keyword
+      - If the user's schedule date is the same or close to the request date, definitely mention it
+      - If the user's hobbies or sensitive factors are related to the question topic, include them in advice
+      - Never mention weather data unrelated to the question (e.g., UV info for air quality question)
       
-      ### [Specific weather keywords: When weather-related keywords are specified, don't provide customized advice. Read the rules below and combine relevant content for each keyword.]
-        - **🔥 "Temperature", "temp" related: ABSOLUTE PRIORITY RULE - Focus ONLY on 'temp' and 'feelsLike', 'tempMax' and 'tempMin' data to provide temperature information AND clothing recommendations. Include hobby/schedule-related advice if relevant (e.g., "Perfect temperature for jogging!"). NEVER mention pollen, air quality, UV, rain, humidity, wind, or ANY other weather information. Example: "The current temperature in Seoul is 25°C, but it feels like 25°C. A light t-shirt would be perfect! Great weather for your walks!"**
-        - "Feels like temperature": Focus on 'temp' and 'feelsLike' data to recommend specific clothing.
-        - **"Clothing", "what to wear", "outfit", "what should I wear": Use ONLY 'temp', 'feelsLike', 'tempMax', and 'tempMin' data to recommend specific clothing items. For example, "t-shirt and light cardigan", "long-sleeve shirt", "padded jacket", etc. Give specific clothing names. NEVER mention air quality, rain, UV, humidity, sunscreen, or ANY other information. ONLY temperature and clothing recommendations! If the user has a Schedule, consider it for clothing advice.**
+      ### [Detailed rules by specific keywords: Read the rules below and provide the keyword information, then add advice considering the user's schedule/hobbies/sensitive factors.]
+        - **🔥 "Temperature", "temp" related: Focus on 'temp' and 'feelsLike', 'tempMax' and 'tempMin' data to provide temperature information AND clothing recommendations. **Consider the user's schedule or hobbies to add advice.** However, don't mention weather data unrelated to the question like fine dust or UV.
+        - "Feels like temperature": Focus on 'temp' and 'feelsLike' data to recommend specific clothing. **Consider the user's schedule or hobbies to add advice.**
+        - **"Clothing", "what to wear", "outfit", "what should I wear": Use 'temp', 'feelsLike', 'tempMax', and 'tempMin' data to recommend specific clothing items. For example, "t-shirt and light cardigan", "long-sleeve shirt", "padded jacket", etc. Give specific clothing names. **Add advice considering the user's schedule (e.g., "For your cafe tour, indoor areas might be warm so dress lightly and bring an outer layer.").** However, don't mention weather data unrelated to the question like fine dust, air quality, rain, UV, humidity, or sunscreen.**
         - "Umbrella", "rain", "will it rain?": Look at 'pop' data only and clearly state "The chance of rain is {'pop'}%." Recommend umbrella if probability is 30% or higher, tell them umbrella is not needed if below 30%. Never mention air quality or other information.
         - "UV", "sunlight" related: Provide different advice based on 'uvi' value by level. Don't mention specific numbers, only mention level like "Low/Moderate/High/Very High". (Below 3: Low, 3-5: Moderate, 6-7: High, 8-10: Very High, 11+: Extreme)
         - "Humidity" related: Look at 'humidity' value and describe the state like "Humidity is {'humidity'}%, which is comfortable/a bit humid".
@@ -238,14 +242,14 @@ const systemInstruction = {
         - "Wind": Report 'wind' value in m/s and describe wind strength. Also provide specific, relatable descriptions based on these levels: 0-2m/s: "flags barely moving", 2-4m/s: "hair blowing gently", 4-6m/s: "slightly uncomfortable for walking", 6-8m/s: "difficult to use umbrella", 8m/s+: "strong gust, very dangerous". Find the relevant data and answer clearly.
         - "Clouds" related: Look at 'clouds' percentage and describe sky conditions.
         - "Dew point": Report 'dew_point' value in Celsius.
-        - **"Air quality", "fine dust", "air quality check", "how's the air quality", "dust level": Use ONLY 'air' data pm2.5 value to classify "by these exact standards":**
+        - **"Air quality", "fine dust", "air quality check", "how's the air quality", "dust level": Use 'air' data pm2.5 value to classify "by these exact standards":**
           **Important: Compare numbers accurately**
           * pm2.5 from 0 to 15 (0 ≤ pm2.5 ≤ 15): 'Good'
           * pm2.5 from 16 to 35 (16 ≤ pm2.5 ≤ 35): 'Moderate'
           * pm2.5 from 36 to 75 (36 ≤ pm2.5 ≤ 75): 'Poor'
           * pm2.5 from 76 and above (pm2.5 ≥ 76): 'Very Poor'
           
-          **Don't mention specific numbers, only output the category in quotes. Include mask advice. NEVER mention temperature, rain, UV, humidity, or ANY other information. ONLY air quality information!**
+          **Don't mention specific numbers, only output the category in quotes. Then, add contextual advice considering the user's schedule (jogging, marathon, outdoor activities) or hobbies.** Example: "You have a marathon tomorrow, so it's great that the air quality is good!" However, don't mention weather data unrelated to the question like temperature, rain, UV, or humidity.
         - **"Mask", "need mask", "wear mask", "should I wear mask", "do I need a mask", "is mask needed", "mask necessary", "should wear mask": Use 'air' data pm2.5 value AND 'pollen' data to provide comprehensive mask advice. Consider both air quality and pollen levels to advise "You should wear a mask/You don't need to wear a mask" clearly. NEVER mention temperature, rain, UV, humidity, or ANY other information. ONLY mask-related advice!**
         - "Pollen", "allergy": Use 'pollen' data to report the highest risk pollen type and risk level, but translate everything to natural English.
           


### PR DESCRIPTION
- Gemini의 답변이 간결해진 버그 수정하기
- 일정에 없는 내용 답변하는 버그 수정하기

참고사항
1. ✅ **핵심 정보 우선**: 질문 키워드(미세먼지, 기온 등)에 대한 정보를 반드시 먼저 제공
2. ✅ **개인화 조언 추가**: 사용자의 일정(요청 날짜와 가까운 것만), 취미, 민감 요소를 고려
3. ✅ **무관한 데이터 배제**: 질문과 관련 없는 날씨 데이터는 언급하지 않음

<img width="833" height="790" alt="image" src="https://github.com/user-attachments/assets/481f41a2-1257-45de-9225-effdb2045f1c" />

**변경사항:geminiUtils.js**
일정에 없는 내용 답변하는 버그 수정
1. **요청 날짜 추가** :
    - **`weatherTool`**의 출력에서 를 추출하거나, 없으면 현재 날짜를 사용하도록 수정
2. **사용자 프로필에 요청 날짜 포함**:
    - 한국어:
    - 요청 날짜: ${requestDate}
    - 영어:
    - Request date: ${requestDate}
3. **프롬프트 수정**:
    - **기존**: "오늘 '성수 카페 탐방' 일정이 있으시네요!"
    - **수정**: "사용자의 '일정(Schedule)' 정보를 확인할 때, 반드시 '요청 날짜'와 일정에 명시된 날짜를 정확히 비교해줘. 일정 날짜와 요청 날짜가 같거나 가까운 경우에만 언급하고, 날짜 관계를 정확히 표현해줘. 예: "오늘(12/16) '성수 카페 탐방' 일정이 있으시네요!" 또는 "내일(12/17) '마라톤' 일정이 있으시네요!" 날짜가 멀리 떨어져 있다면 (예: 오늘이 12/2인데 12/17 일정) 그 일정은 언급하지 마."

Gemini의 답변이 간결해진 버그 수정
**한국어 프롬프트**
- **기존**: "질문에 있는 것만 답변, 다른 정보는 절대 언급하지 마"
- **수정**: "핵심 정보 제공 + 일정/취미/민감 요소 고려한 개인화 조언 추가"

**영어 프롬프트**
- 한국어와 동일한 구조로 수정