### PR TITLE
"프론트엔드 연결" 콘솔 로그 삭제

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -60,10 +60,6 @@ const wss = new WebSocketServer({ server });
 
 console.log('--- Lumee 백엔드 서버 시작 ---');
 
-wss.on('connection', ws => {
-    console.log('[웹소켓] 프론트엔드와 연결되었습니다.');
-});
-
 // 라즈베리파이로부터 Wi-Fi를 통해 노크 신호를 받을 엔드포인트
 app.post('/knock', (req, res) => {
     console.log('[HTTP] ✊ 라즈베리파이로부터 "KNOCK" 신호 수신!');


### PR DESCRIPTION
<img width="870" height="210" alt="image" src="https://github.com/user-attachments/assets/7a44d3fd-e00a-4ca6-a267-9dc989d62ffb" />

백엔드 콘솔 로그에서 이벤트가 발생할때 마다 "[웹소켓] 프론트엔드와 연결되었습니다."가 출력되는 문제 해결

변경사항:
server.js
- 콘솔 로그를 출력하는 부분 삭제